### PR TITLE
Support for Mongoid

### DIFF
--- a/lib/devise/async/proxy.rb
+++ b/lib/devise/async/proxy.rb
@@ -11,7 +11,7 @@ module Devise
       end
 
       def deliver
-        Worker.enqueue(@method, @resource.class.name, @resource.id)
+        Worker.enqueue(@method, @resource.class.name, @resource.to_param)
       end
     end
   end

--- a/test/devise/async/proxy_test.rb
+++ b/test/devise/async/proxy_test.rb
@@ -5,7 +5,7 @@ module Devise
     describe "Proxy" do
       it "gets called by devise operations and proxy to worker" do
         user = create_user
-        Worker.expects(:enqueue).with(:confirmation_instructions, "User", user.id)
+        Worker.expects(:enqueue).with(:confirmation_instructions, "User", user.to_param)
         user.send_confirmation_instructions
       end
     end


### PR DESCRIPTION
When calling `id` on Mongoid document it returns `BSON::ObjectId` object. When this object is used as argument for resque job it is serialized to `{"$oid"=> "4fc09874af84033b3800016c"}`. Later on this hash is passed to `find` which fails.

You should use `to_param` method which returns string representation of id. This change should work with different ORMs -- it's part of ActiveModel.
