### PR TITLE
Only delay notifications until after_commit callback if model has changed

### DIFF
--- a/lib/devise/async/model.rb
+++ b/lib/devise/async/model.rb
@@ -10,7 +10,11 @@ module Devise
       protected
 
       def send_devise_notification(notification)
-        devise_pending_notifications << notification
+        if self.changed?
+          devise_pending_notifications << notification
+        else
+          Devise::Async::Worker.enqueue(notification, self.class.name, self.id.to_s)
+        end
       end
 
       def send_devise_pending_notifications

--- a/test/devise/async/model_test.rb
+++ b/test/devise/async/model_test.rb
@@ -3,18 +3,38 @@ require "test_helper"
 module Devise
   module Async
     describe "Model" do
-      it "accumulates notifications to be send after commit" do
+      it "accumulates notifications to be sent after commit on Model creation" do
+        Admin.transaction do
+          admin = create_admin
+          admin.send(:devise_pending_notifications).must_equal [:confirmation_instructions]
+        end
+      end
+      
+      it "immediately sends notifications when the model has not changed" do
         admin = create_admin
+        Worker.expects(:enqueue).with(:confirmation_instructions, "Admin", admin.id.to_s)
         admin.send_confirmation_instructions
-        admin.send(:devise_pending_notifications).must_equal [:confirmation_instructions]
-        Worker.expects(:enqueue).never
+      end
+      
+      it "accumulates notifications to be sent after commit when Model has been changed" do
+        admin = create_admin
+        Admin.transaction do
+          admin[:username] = "changed_username"
+          admin.send_confirmation_instructions
+          admin.send(:devise_pending_notifications).must_equal [:confirmation_instructions]
+          Worker.expects(:enqueue).never # after_commit will not fire without save
+        end
       end
 
-      it "triggers enqueues the notifications on save" do
+      it "triggers the enqueued notifications on save" do
         admin = create_admin
-        admin.send_confirmation_instructions
-        Worker.expects(:enqueue).with(:confirmation_instructions, "Admin", admin.id.to_s)
-        admin.update_attribute(:username, "newusername")
+        Admin.transaction do
+          admin[:username] = "changed_username"
+          admin.send_confirmation_instructions
+          admin.send(:devise_pending_notifications).must_equal [:confirmation_instructions]
+          admin.save
+          Worker.expects(:enqueue).with(:confirmation_instructions, "Admin", admin.id.to_s)
+        end
       end
     end
   end


### PR DESCRIPTION
Here's a pull request with the change referenced in Issue 6:
https://github.com/mhfs/devise-async/issues/6#issuecomment-7261405

Let me know if the tests look alright.  I haven't worked too much with mini-test.  Perhaps there's a better way to manage the transactions.

Thanks,
Dennis
