### PR TITLE
Added support for "QueueClassic" backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Supported backends:
 * Resque
 * Sidekiq
 * Delayed::Job
+* QueueClassic
 
 ## Installation
 
@@ -37,7 +38,7 @@ end
 Set your queuing backend by creating `config/initializers/devise_async.rb`:
 
 ```ruby
-# Supported options: :resque, :sidekiq, :delayed_job
+# Supported options: :resque, :sidekiq, :delayed_job, :queue_classic
 Devise::Async.backend = :resque
 ```
 
@@ -70,7 +71,7 @@ Devise::Async.mailer = "MyCustomMailer"
 ### Custom queue
 
 Let you specify a custom queue where to enqueue your background Devise jobs. Works
-only for Resque and Sidekiq. Defaults to :mailer.
+only for Resque, Sidekiq and QueueClassic. Defaults to :mailer.
 
 ```ruby
 # config/initializers/devise_async.rb

--- a/devise-async.gemspec
+++ b/devise-async.gemspec
@@ -4,8 +4,8 @@ require File.expand_path('../lib/devise/async/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["Marcelo Silveira"]
   gem.email         = ["marcelo@mhfs.com.br"]
-  gem.description   = %q{Send Devise's emails in background. Supports Resque, Sidekiq and Delayed::Job.}
-  gem.summary       = %q{Devise Async provides an easy way to configure Devise to send its emails asynchronously using your preferred queuing backend. It supports Resque, Sidekiq and Delayed::Job.}
+  gem.description   = %q{Send Devise's emails in background. Supports Resque, Sidekiq, Delayed::Job and QueueClassic.}
+  gem.summary       = %q{Devise Async provides an easy way to configure Devise to send its emails asynchronously using your preferred queuing backend. It supports Resque, Sidekiq, Delayed::Job and QueueClassic.}
   gem.homepage      = "https://github.com/mhfs/devise-async/"
 
   gem.files         = `git ls-files`.split($\)
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "resque",                    "~> 1.20"
   gem.add_development_dependency "sidekiq",                   "~> 1.2"
   gem.add_development_dependency "delayed_job_active_record", "~> 0.3"
+  gem.add_development_dependency "queue_classic",             "~> 2.0"
   gem.add_development_dependency "mocha",                     "~> 0.11"
   gem.add_development_dependency "minitest",                  "~> 3.0"
 end

--- a/lib/devise/async.rb
+++ b/lib/devise/async.rb
@@ -9,10 +9,11 @@ module Devise
     autoload :Model,   "devise/async/model"
 
     module Backend
-      autoload :Base,       "devise/async/backend/base"
-      autoload :Resque,     "devise/async/backend/resque"
-      autoload :Sidekiq,    "devise/async/backend/sidekiq"
-      autoload :DelayedJob, "devise/async/backend/delayed_job"
+      autoload :Base,         "devise/async/backend/base"
+      autoload :Resque,       "devise/async/backend/resque"
+      autoload :Sidekiq,      "devise/async/backend/sidekiq"
+      autoload :DelayedJob,   "devise/async/backend/delayed_job"
+      autoload :QueueClassic, "devise/async/backend/queue_classic"
     end
 
     # Defines the queue backend to be used. Resque by default.

--- a/lib/devise/async/backend/queue_classic.rb
+++ b/lib/devise/async/backend/queue_classic.rb
@@ -1,0 +1,20 @@
+require "queue_classic"
+
+module Devise
+  module Async
+    module Backend
+      class QueueClassic < Base
+        def self.enqueue(method, *args)
+          queue = ::QC::Queue.new(Devise::Async.queue)
+          method = String(method) # QC won't serialize Symbol such as #{method}
+          args.unshift("#{self}.perform", method)
+          queue.enqueue(*args)
+        end
+
+        def self.perform(method, resource_class, resource_id)
+          new.perform(method, resource_class, resource_id)
+        end
+      end
+    end
+  end
+end

--- a/test/devise/async/backend/queue_classic_test.rb
+++ b/test/devise/async/backend/queue_classic_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+module Devise
+  module Async
+    module Backend
+      describe "QueueClassic" do
+        it "enqueues job" do
+          ::QC::Queue.any_instance.expects(:enqueue).with(
+              "Devise::Async::Backend::QueueClassic.perform",
+              "mailer_method", "User", 123)
+          QueueClassic.enqueue(:mailer_method, "User", 123)
+        end
+
+        it "delegates to devise mailer when delivering" do
+          user = create_user
+          ActionMailer::Base.deliveries = []
+          Backend::QueueClassic.perform(:confirmation_instructions, "User", user.id)
+          ActionMailer::Base.deliveries.size.must_equal 1
+        end
+
+        it "enqueues to configured queue" do
+          queue = mock(:enqueue => nil)
+          ::QC::Queue.expects(:new).with(:custom_queue).once.returns(queue)
+          QueueClassic.enqueue(:mailer_method, "User", 123)
+        end
+      end
+    end
+  end
+end

--- a/test/devise/async/backend_test.rb
+++ b/test/devise/async/backend_test.rb
@@ -15,6 +15,10 @@ module Devise
         Backend.for(:delayed_job).must_equal Backend::DelayedJob
       end
 
+      it "gives queue classic as the backend" do
+        Backend.for(:queue_classic).must_equal Backend::QueueClassic
+      end
+
       it "alerts about unsupported backend" do
         assert_raises ArgumentError do
           Backend.for(:unsupported_backend)

--- a/test/devise/async/worker_test.rb
+++ b/test/devise/async/worker_test.rb
@@ -23,6 +23,13 @@ module Devise
         Backend::DelayedJob.expects(:enqueue).with(:mailer_method, "User", 123)
         Worker.enqueue(:mailer_method, "User", 123)
       end
+
+      it "enqueues job using the queue classic backend" do
+        Devise::Async.backend = :queue_classic
+
+        Backend::QueueClassic.expects(:enqueue).with(:mailer_method, "User", 123)
+        Worker.enqueue(:mailer_method, "User", 123)
+      end
     end
   end
 end


### PR DESCRIPTION
Please find in this pull request a new [QueueClassic](https://github.com/ryandotsmith/queue_classic) backend for devise-async.

Since testing QueueClassic requires access to a real postgres database I used mocks instead.
The QC API is simple enough but to be sure I also validated my new adapter on my own rails application.

Please note: queue_classic does not listen to a placeholder queue like Resque, so you should be careful with the queue names. Out of the box devise-async and qc will not interact as they use different default queues. The user should either configure `Devise::Async.queue = 'default'` or tell `rake qc:work` to listen on `QUEUE=mailer`.
