### PR TITLE
Allow for callbacks to the model on mail actually being sent

### DIFF
--- a/lib/devise/async.rb
+++ b/lib/devise/async.rb
@@ -28,14 +28,24 @@ module Devise
     mattr_accessor :queue
     @@queue = :mailer
 
+    # Defines whether the callback hook should be called on the model. Note this uses
+    # respond_to? so can be left on for models that don't have the method. This expects
+    # a method called *mail_sent* to exist on the model and it will be passed the template
+    # that devise has mailed out. This allows any logging or processing that needs to
+    # occur after a mail has actually gone out to be handled. Note that it does not
+    # guarantee mail delivery; just that it has left the rails system!
+    mattr_accessor :callback
+    @@callback = false
+
     # Allow configuring Devise::Async with a block
     #
     # Example:
     #
     #     Devise::Async.setup do |config|
-    #       config.backend = :resque
-    #       config.mailer  = "MyMailer"
-    #       config.queue   = :my_custom_queue
+    #       config.backend  = :resque
+    #       config.mailer   = "MyMailer"
+    #       config.queue    = :my_custom_queue
+    #       config.callback = true
     #     end
     def self.setup
       yield self

--- a/lib/devise/async/backend/base.rb
+++ b/lib/devise/async/backend/base.rb
@@ -3,16 +3,23 @@ module Devise
     module Backend
       class Base
         def self.enqueue(*args)
-          raise NotImplementedError, "Any DeviseAssync::Backend subclass should implement `self.enqueue`."
+          raise NotImplementedError, "Any DeviseAsync::Backend subclass should implement `self.enqueue`."
         end
 
         # Loads the resource record and sends the email.
         #
         # It uses `orm_adapter` API to fetch the record in order to enforce
         # compatibility among diferent ORMs.
-        def perform(method, resource_class, resource_id)
+        def perform(method, resource_class, resource_id, options)
           resource = resource_class.constantize.to_adapter.get!(resource_id)
-          mailer_class.send(method, resource).deliver
+          mail = nil
+          if mailer_class.instance_method(method).arity == 1
+            mail = mailer_class.send(method, resource).deliver
+          else
+            mail = mailer_class.send(method, resource, options).deliver
+          end
+          resource.devise_mail_sent(method) if Devise::Async.callback && resource.respond_to?(:devise_mail_sent)
+          mail
         end
 
         private

--- a/lib/devise/async/backend/queue_classic.rb
+++ b/lib/devise/async/backend/queue_classic.rb
@@ -11,8 +11,8 @@ module Devise
           queue.enqueue(*args)
         end
 
-        def self.perform(method, resource_class, resource_id)
-          new.perform(method, resource_class, resource_id)
+        def self.perform(method, resource_class, resource_id, options)
+          new.perform(method, resource_class, resource_id, options)
         end
       end
     end

--- a/lib/devise/async/backend/resque.rb
+++ b/lib/devise/async/backend/resque.rb
@@ -9,8 +9,8 @@ module Devise
           ::Resque.enqueue(*args)
         end
 
-        def self.perform(method, resource_class, resource_id)
-          new.perform(method, resource_class, resource_id)
+        def self.perform(method, resource_class, resource_id, options)
+          new.perform(method, resource_class, resource_id, options)
         end
       end
     end

--- a/lib/devise/async/proxy.rb
+++ b/lib/devise/async/proxy.rb
@@ -13,7 +13,7 @@ module Devise
       def deliver
         # Use `id.to_s` to avoid problems with mongoid 2.4.X ids being serialized
         # wrong with YAJL.
-        Worker.enqueue(@method, @resource.class.name, @resource.id.to_s)
+        Worker.enqueue(@method, @resource.class.name, @resource.id.to_s, @resource.mail_options(@method))
       end
     end
   end

--- a/lib/devise/async/worker.rb
+++ b/lib/devise/async/worker.rb
@@ -3,8 +3,8 @@ module Devise
     class Worker
       # Used is the internal interface for devise-async to enqueue notifications
       # to the desired backend.
-      def self.enqueue(method, resource_class, resource_id)
-        backend_class.enqueue(method, resource_class, resource_id)
+      def self.enqueue(method, resource_class, resource_id, options)
+        backend_class.enqueue(method, resource_class, resource_id, options)
       end
 
       private

--- a/test/devise/async/backend/base_test.rb
+++ b/test/devise/async/backend/base_test.rb
@@ -10,11 +10,69 @@ module Devise
           mailer_instance = mock(:deliver => true)
 
           MyMailer.expects(:confirmation_instructions).once.returns(mailer_instance)
-          Base.new.perform(:confirmation_instructions, "User", user.id)
+          Base.new.perform(:confirmation_instructions, "User", user.id, {})
+        end
+
+        it "delegates to a mailer that uses options" do
+          Async.mailer = "OptionsMailer"
+          user = create_user
+          mailer_instance = mock(:deliver => true)
+
+          OptionsMailer.expects(:reset_password_instructions).with(user, {:a => 1}).returns(mailer_instance)
+          Base.new.perform(:reset_password_instructions, "User", user.id, {:a => 1})
+        end
+
+        it "performs a callback" do
+          Async.callback = true
+          user = create_user
+          mailer_instance = mock(:deliver => true)
+
+          Devise::Mailer.expects(:confirmation_instructions).once.returns(mailer_instance)
+
+          User.any_instance.expects(:devise_mail_sent).once
+          assert user.respond_to?(:devise_mail_sent)
+
+          Base.new.perform(:confirmation_instructions, "User", user.id, user.mail_options(:confirmation_instructions))
+        end
+
+        it "does not perform a callback for models without the method" do
+          Async.callback = true
+          admin = create_admin
+          mailer_instance = mock(:deliver => true)
+
+          Devise::Mailer.expects(:confirmation_instructions).once.returns(mailer_instance)
+
+          # Cannot do this properly as mocha adds missing methods that are expected...!
+          # If had access to the instance (rather than Class.any_instance) could use
+          # responds_like but there isn't!
+          # Ideally it would be:
+          # Admin.any_instance.responds_like(Admin.new)
+          # Admin.any_instance.expects(:devise_mail_sent).never
+          # Instead, turned off stubbing of non-existent methods in Mocha config,
+          # hence testing to ensure that exception is raised on the mock objects.
+          assert_raises Mocha::StubbingError do
+            Admin.any_instance.expects(:devise_mail_sent).never
+          end
+          assert !admin.respond_to?(:devise_mail_sent)
+
+          Base.new.perform(:confirmation_instructions, "Admin", admin.id, nil)
+        end
+
+        it "does not perform a callback" do
+          Async.callback = false
+          user = create_user
+          mailer_instance = mock(:deliver => true)
+
+          Devise::Mailer.expects(:confirmation_instructions).once.returns(mailer_instance)
+          User.any_instance.expects(:devise_mail_sent).never
+          assert user.respond_to?(:devise_mail_sent)
+
+          Base.new.perform(:confirmation_instructions, "User", user.id, user.mail_options(:confirmation_instructions))
         end
 
         after do
           Async.mailer = "Devise::Mailer"
+          Async.callback = false
         end
       end
     end

--- a/test/devise/async/backend/delayed_job_test.rb
+++ b/test/devise/async/backend/delayed_job_test.rb
@@ -15,7 +15,7 @@ module Devise
         it "delegates to devise mailer when delivering" do
           user = create_user
           ActionMailer::Base.deliveries = []
-          Backend::DelayedJob.new.perform(:confirmation_instructions, "User", user.id)
+          Backend::DelayedJob.new.perform(:confirmation_instructions, "User", user.id, user.mail_options(:confirmation_instructions))
           ActionMailer::Base.deliveries.size.must_equal 1
         end
       end

--- a/test/devise/async/backend/queue_classic_test.rb
+++ b/test/devise/async/backend/queue_classic_test.rb
@@ -14,7 +14,7 @@ module Devise
         it "delegates to devise mailer when delivering" do
           user = create_user
           ActionMailer::Base.deliveries = []
-          Backend::QueueClassic.perform(:confirmation_instructions, "User", user.id)
+          Backend::QueueClassic.perform(:confirmation_instructions, "User", user.id, user.mail_options(:confirmation_instructions))
           ActionMailer::Base.deliveries.size.must_equal 1
         end
 

--- a/test/devise/async/backend/resque_test.rb
+++ b/test/devise/async/backend/resque_test.rb
@@ -12,7 +12,7 @@ module Devise
         it "delegates to devise mailer when delivering" do
           user = create_user
           ActionMailer::Base.deliveries = []
-          Backend::Resque.perform(:confirmation_instructions, "User", user.id)
+          Backend::Resque.perform(:confirmation_instructions, "User", user.id, user.mail_options(:confirmation_instructions))
           ActionMailer::Base.deliveries.size.must_equal 1
         end
 
@@ -20,6 +20,11 @@ module Devise
           expected_size = 1 + ::Resque.size(:custom_queue)
           Resque.enqueue(:mailer_method, "User", 123)
           ::Resque.size(:custom_queue).must_equal expected_size
+        end
+
+        it "enqueues with options" do
+          ::Resque.expects(:enqueue).with(Resque, :mailer_method, "User", 123, {})
+          Resque.enqueue(:mailer_method, "User", 123, {})
         end
       end
     end

--- a/test/devise/async/backend/sidekiq_test.rb
+++ b/test/devise/async/backend/sidekiq_test.rb
@@ -12,13 +12,13 @@ module Devise
         it "delegates to devise mailer when delivering" do
           user = create_user
           ActionMailer::Base.deliveries = []
-          Backend::Sidekiq.new.perform(:confirmation_instructions, "User", user.id)
+          Backend::Sidekiq.new.perform(:confirmation_instructions, "User", user.id, user.mail_options(:confirmation_instructions))
           ActionMailer::Base.deliveries.size.must_equal 1
         end
 
         it "enqueues to configured queue" do
           expected_size = 1 + Sidekiq.jobs.size
-          Sidekiq.enqueue(:mailer_method, "User", 123)
+          Sidekiq.enqueue(:mailer_method, "User", 123, {})
           Sidekiq.jobs.size.must_equal expected_size
         end
       end

--- a/test/devise/async/proxy_test.rb
+++ b/test/devise/async/proxy_test.rb
@@ -5,7 +5,7 @@ module Devise
     describe "Proxy" do
       it "gets called by devise operations and proxy to worker" do
         user = create_user
-        Worker.expects(:enqueue).with(:confirmation_instructions, "User", user.id.to_s)
+        Worker.expects(:enqueue).with(:confirmation_instructions, "User", user.id.to_s, {})
         user.send_confirmation_instructions
       end
     end

--- a/test/devise/async/worker_test.rb
+++ b/test/devise/async/worker_test.rb
@@ -6,29 +6,29 @@ module Devise
       it "enqueues job using the resque backend" do
         Devise::Async.backend = :resque
 
-        Backend::Resque.expects(:enqueue).with(:mailer_method, "User", 123)
-        Worker.enqueue(:mailer_method, "User", 123)
+        Backend::Resque.expects(:enqueue).with(:mailer_method, "User", 123, nil)
+        Worker.enqueue(:mailer_method, "User", 123, nil)
       end
 
       it "enqueues job using the sidekiq backend" do
         Devise::Async.backend = :sidekiq
 
-        Backend::Sidekiq.expects(:enqueue).with(:mailer_method, "User", 123)
-        Worker.enqueue(:mailer_method, "User", 123)
+        Backend::Sidekiq.expects(:enqueue).with(:mailer_method, "User", 123, nil)
+        Worker.enqueue(:mailer_method, "User", 123, nil)
       end
 
       it "enqueues job using the delayed job backend" do
         Devise::Async.backend = :delayed_job
 
-        Backend::DelayedJob.expects(:enqueue).with(:mailer_method, "User", 123)
-        Worker.enqueue(:mailer_method, "User", 123)
+        Backend::DelayedJob.expects(:enqueue).with(:mailer_method, "User", 123, nil)
+        Worker.enqueue(:mailer_method, "User", 123, nil)
       end
 
       it "enqueues job using the queue classic backend" do
         Devise::Async.backend = :queue_classic
 
-        Backend::QueueClassic.expects(:enqueue).with(:mailer_method, "User", 123)
-        Worker.enqueue(:mailer_method, "User", 123)
+        Backend::QueueClassic.expects(:enqueue).with(:mailer_method, "User", 123, nil)
+        Worker.enqueue(:mailer_method, "User", 123, nil)
       end
     end
   end

--- a/test/devise/async_test.rb
+++ b/test/devise/async_test.rb
@@ -16,9 +16,15 @@ module Devise
       Async.mailer.must_equal "MyMailer"
     end
 
+    it "stores callback" do
+      Async.callback = true
+      Async.callback.must_equal true
+    end
+
     after do
       Async.backend = :resque
       Async.mailer = "Devise::Mailer"
+      Async.callback = false
     end
   end
 end

--- a/test/support/options_mailer.rb
+++ b/test/support/options_mailer.rb
@@ -1,0 +1,4 @@
+class OptionsMailer < Devise::Mailer
+  def reset_password_instructions(record, options)
+  end
+end

--- a/test/support/rails_app/app/models/user.rb
+++ b/test/support/rails_app/app/models/user.rb
@@ -1,5 +1,13 @@
 class User < ActiveRecord::Base
   devise :database_authenticatable, :confirmable, :lockable, :recoverable,
     :registerable, :rememberable, :timeoutable, :token_authenticatable,
-    :trackable, :validatable
+    :trackable, :validatable, :async
+
+  def devise_mail_sent(method)
+    method
+  end
+
+  def mail_options(notification)
+    {}
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ ENV["RAILS_ENV"] = "test"
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/mock"
-require "mocha"
+require "mocha/setup"
 
 require "devise"
 require "devise/async"
@@ -16,5 +16,8 @@ require "sidekiq/testing"
 require "support/rails_app"
 require "support/helpers"
 require "support/my_mailer"
+require "support/options_mailer"
 
 load File.dirname(__FILE__) + "/support/rails_app/db/schema.rb"
+
+Mocha::Configuration.prevent(:stubbing_non_existent_method)


### PR DESCRIPTION
(rather than when queued).  Also allow for options to be stored as queue parameters for data that may be available when the email is queued, but not when the mail is sent, but should not be properly persisted into the database.

Using this variant with our code and a Resque backend and seeing the desired behaviour. For example on our customer model....

``` ruby
devise ..., :async
...
def mail_options(notification)
  {
    :extra_param => "request data"
  }
end

def devise_mail_sent(method)
  if method == :reset_password_instructions
    # Log a reset...
  end
end
```

And then in the custom mailer:

``` ruby
class OurMailer < Devise::Mailer
  def reset_password_instructions(record, options)
    if options.empty? || options.blank?
      # Log out warning
    else
      # Act on options[:extra_param]
    end
    devise_mail(record, :reset_password_instructions)
  end
end
```

I've added tests where I can though mocha is a little too clever with it's expects/method_missing to allow proper testing of the responds_to? code I've written :(
