### PR TITLE
devise 2.2.0 isn't compatible

### DIFF
--- a/devise-async.gemspec
+++ b/devise-async.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Devise::Async::VERSION
 
-  gem.add_dependency "devise", ">= 1.1"
+  gem.add_dependency "devise", ">= 1.1", "< 2.2.0"
 
   gem.add_development_dependency "activerecord",              "~> 3.2"
   gem.add_development_dependency "actionpack",                "~> 3.2"


### PR DESCRIPTION
devise-asyn isn't compatible to devise 2.2.0 because of
- All mailer methods now expect a second argument with delivery options

https://github.com/plataformatec/devise/blob/master/CHANGELOG.rdoc
