### PR TITLE
send_confirmation_instructions broken on queue_classic

### DIFF
--- a/lib/devise/async/worker.rb
+++ b/lib/devise/async/worker.rb
@@ -4,6 +4,7 @@ module Devise
       # Used is the internal interface for devise-async to enqueue notifications
       # to the desired backend.
       def self.enqueue(method, resource_class, resource_id, opts)
+        opts.stringify_keys! # for queue_classic compatibility
         backend_class.enqueue(method, resource_class, resource_id, opts)
       end
 


### PR DESCRIPTION
Devise passes a `to` key as a symbol in the `send_confirmation_instructions` method:
https://github.com/plataformatec/devise/blob/master/lib/devise/models/confirmable.rb#L91

This breaks queue_classic which expects all keys to be string. This pull request calls stringify_keys! on the opts hash before passing it on to the configured worker.
