### PR TITLE
Added the option to set a priority for DJ and Backburner

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Defaults to :mailer.
 Devise::Async.queue = :my_custom_queue
 ```
 
+### Custom priority
+
+You can specify a custom priority for created background jobs in Devise or Backburner.
+If no value is specified, jobs will be enqueued with whatever default priority is configured in Devise or Backburner.
+
+```ruby
+# config/initializers/devise_async.rb
+Devise::Async.priority = 10
+```
+
 ### Setup via block
 
 To avoid repeating `Devise::Async` in the initializer file you can use the block syntax

--- a/lib/devise/async.rb
+++ b/lib/devise/async.rb
@@ -25,6 +25,10 @@ module Devise
     mattr_accessor :queue
     @@queue = :mailer
 
+    # Defines the priority in which the background job will be enqueued. Defaults to the default of the backend you are using.
+    mattr_accessor :priority
+    @@priority = nil
+
     # Defines the enabled configuration that if set to false the emails will be sent synchronously
     mattr_accessor :enabled
     @@enabled = true

--- a/lib/devise/async/backend/backburner.rb
+++ b/lib/devise/async/backend/backburner.rb
@@ -15,6 +15,10 @@ module Devise
         def self.queue
           Devise::Async.queue
         end
+
+        def self.queue_priority
+          Devise::Async.priority.nil? ? ::Backburner.configuration.default_priority : Devise::Async.priority
+        end
       end
     end
   end

--- a/lib/devise/async/backend/delayed_job.rb
+++ b/lib/devise/async/backend/delayed_job.rb
@@ -3,7 +3,11 @@ module Devise
     module Backend
       class DelayedJob < Base
         def self.enqueue(*args)
-          new.delay(:queue => Devise::Async.queue).perform(*args)
+          new.delay(:queue => Devise::Async.queue, :priority => priority).perform(*args)
+        end
+
+        def self.priority
+          Devise::Async.priority.nil? ? Delayed::Worker.default_priority : Devise::Async.priority
         end
       end
     end

--- a/test/devise/async/backend/backburner_test.rb
+++ b/test/devise/async/backend/backburner_test.rb
@@ -15,6 +15,18 @@ module Devise
           Backend::Backburner.perform(:confirmation_instructions, "User", user.id, {})
           ActionMailer::Base.deliveries.size.must_equal 1
         end
+
+        describe ".queue_priority" do
+          it "returns the right priority when set" do
+            Devise::Async.priority = 15
+            Backburner.queue_priority.must_equal 15
+            Devise::Async.priority = nil
+          end
+
+          it "returns default priority when no priority is set" do
+            Backburner.queue_priority.must_equal ::Backburner.configuration.default_priority
+          end
+        end
       end
     end
   end

--- a/test/devise/async/backend/delayed_job_test.rb
+++ b/test/devise/async/backend/delayed_job_test.rb
@@ -7,7 +7,7 @@ module Devise
         it "enqueues job" do
           delayed_instance = mock()
           delayed_instance.expects(:perform).once.with(:mailer_method, "User", 123, {})
-          DelayedJob.any_instance.expects(:delay).once.returns(delayed_instance)
+          DelayedJob.any_instance.expects(:delay).with(:queue => Devise::Async.queue, :priority => DelayedJob.priority).once.returns(delayed_instance)
 
           DelayedJob.enqueue(:mailer_method, "User", 123, {})
         end
@@ -17,6 +17,18 @@ module Devise
           ActionMailer::Base.deliveries = []
           Backend::DelayedJob.new.perform(:confirmation_instructions, "User", user.id, {})
           ActionMailer::Base.deliveries.size.must_equal 1
+        end
+
+        describe ".priority" do
+          it "returns it when the priority is set" do
+            Devise::Async.priority = 15
+            DelayedJob.priority.must_equal 15
+            Devise::Async.priority = nil
+          end
+
+          it "returns the default DJ priority when the priority is not set it" do
+            DelayedJob.priority.must_equal Delayed::Worker.default_priority
+          end
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,8 @@ require "minitest/spec"
 require "minitest/mock"
 require "mocha/setup"
 
+require "action_controller"
+
 require "devise"
 require "devise/async"
 require "rails/all"


### PR DESCRIPTION
`Delayed::Job` and `Backburner` allow setting a numeric priority in addition to the queue name. This is not yet supported by this gem. We need this in our application, because we only use a single default queue with DJ, but different priorities.