### PR TITLE
Сhange default queue name to equal default ActionMailer queue for Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 rvm:
   - 1.9.3
+
 services:
   - redis-server
+
+before_install:
+  - gem install bundler -v 1.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,40 @@
 ## Unreleased
 
-## 0.10.0-alpha
+## 0.10.2
 
-* Backburner support (jandudulski)
-* Sucker Punch support (kmayer)
-* Que support (marshall-lee)
-* Handle `deliver_now` in preparation for Rails 5 (barelyknown)
-* Option to set a priority for DJ and Backburner (mkon)
-* The locale is remembered before an asynchronous task is run (baschtl)
-* Fixed a usage of `try` that appeared in connection with Rails 4 (baschtl)
+* Explicitly requires Devise to avoid an error if Devise is not explicitly mentioned in your Gemfile (@derekprior)
+* Improvements for running devise-async locally and on CI
+* This will be the last release to support Devise 3.x
+
+## 0.10.1
+
+* No code changes compared to `0.10.1-alpha`
+
+## 0.10.1-alpha
+
+* Backburner support (@jandudulski)
+* Sucker Punch support (@kmayer)
+* Que support (@marshall-lee)
+* Handle `deliver_now` in preparation for Rails 5 (@barelyknown)
+* Option to set a priority for DJ and Backburner (@mkon)
+* The locale is remembered before an asynchronous task is run (@baschtl)
+* Fixed a usage of `try` that appeared in connection with Rails 4 (@baschtl)
 
 ## 0.9.0
 
-* Multiple mailers support (baschtl)
+* Multiple mailers support (@baschtl)
 * Update devise dependency to ~3.2
 
 ## 0.8.0
 
-* Support arbitrary number of arguments to mailer (glebm)
-* Added torquebox support (astjohn)
+* Support arbitrary number of arguments to mailer (@glebm)
+* Added torquebox support (@astjohn)
 
 ## 0.7.0
 
 * make sure options hash has string keys when enqueued and symbol keys when job runs
-* stringfy options keys before enqueueing to make queue_classic happy (nickw)
-* Added `Devise::Async.enabled=` options to make it easier to skip async processing during tests (mohamedmagdy)
+* stringfy options keys before enqueueing to make queue_classic happy (@nickw)
+* Added `Devise::Async.enabled=` options to make it easier to skip async processing during tests (@mohamedmagdy)
 
 ## 0.6.0
 
@@ -39,7 +49,7 @@
 
 ## 0.5.0
 
-* Added support for QueueClassic (jperville)
+* Added support for QueueClassic (@jperville)
 * Remove deprecated `DeviseAsync::Proxy` and `DeviseAsync.backend=`
 * Improved comments throughout code
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ trying to set `Devise::Async.mailer` just use `Devise.mailer` instead.
 ### Custom queue
 
 Let you specify a custom queue where to enqueue your background Devise jobs.
-Defaults to :mailer.
+Defaults to :mailers.
 
 ```ruby
 # config/initializers/devise_async.rb

--- a/Rakefile
+++ b/Rakefile
@@ -10,4 +10,5 @@ Rake::TestTask.new do |t|
   t.libs << "test"
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
+  t.warning = false
 end

--- a/devise-async.gemspec
+++ b/devise-async.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
 
-  gem.add_dependency "devise", "~> 3.2"
+  gem.add_dependency "devise", ">= 3.2", "< 4.1"
 
   gem.add_development_dependency "activerecord",              ">= 3.2"
   gem.add_development_dependency "actionpack",                ">= 3.2"

--- a/devise-async.gemspec
+++ b/devise-async.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "devise", ">= 3.2", "< 4.1"
 
+  gem.add_development_dependency "minitest"
   gem.add_development_dependency "activerecord",              ">= 3.2"
   gem.add_development_dependency "actionpack",                ">= 3.2"
   gem.add_development_dependency "actionmailer",              ">= 3.2"
@@ -31,7 +32,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "queue_classic",             "~> 2.0"
   gem.add_development_dependency "backburner",                "~> 0.4"
   gem.add_development_dependency "mocha",                     "~> 0.11"
-  gem.add_development_dependency "minitest",                  "~> 3.0"
   gem.add_development_dependency "torquebox-no-op",           "~> 2.3"
   gem.add_development_dependency "sucker_punch",              "~> 1.0.5"
   gem.add_development_dependency "que",                       "~> 0.8"

--- a/devise-async.gemspec
+++ b/devise-async.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
 
-  gem.add_dependency "devise", ">= 3.2", "< 4.1"
+  gem.add_dependency "devise", "~> 3.2"
 
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "activerecord",              ">= 3.2"

--- a/devise-async.gemspec
+++ b/devise-async.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
 
-  gem.add_dependency "devise", "~> 3.2"
+  gem.add_dependency "devise", ">= 3.2", "< 4.0"
 
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "activerecord",              ">= 3.2"

--- a/lib/devise/async.rb
+++ b/lib/devise/async.rb
@@ -24,9 +24,9 @@ module Devise
     mattr_accessor :backend
     @@backend = :resque
 
-    # Defines the queue in which the background job will be enqueued. Default is :mailer.
+    # Defines the queue in which the background job will be enqueued. Default is :mailers.
     mattr_accessor :queue
-    @@queue = :mailer
+    @@queue = :mailers
 
     # Defines the priority in which the background job will be enqueued. Defaults to the default of the backend you are using.
     mattr_accessor :priority

--- a/lib/devise/async/version.rb
+++ b/lib/devise/async/version.rb
@@ -1,5 +1,5 @@
 module Devise
   module Async
-    VERSION = "0.10.1"
+    VERSION = "0.10.2"
   end
 end

--- a/lib/devise/async/worker.rb
+++ b/lib/devise/async/worker.rb
@@ -3,33 +3,33 @@ module Devise
     class Worker
       class << self
 
-      # Used is the internal interface for devise-async to enqueue notifications
-      # to the desired backend.
-      def enqueue(method, resource_class, resource_id, *args)
-        # convert args to strings and hashes with string keys before passing to backend
-        args = stringify_args args
-        backend_class.enqueue(method, resource_class, resource_id, *args)
-      end
+        # Used is the internal interface for devise-async to enqueue notifications
+        # to the desired backend.
+        def enqueue(method, resource_class, resource_id, *args)
+          # convert args to strings and hashes with string keys before passing to backend
+          args = stringify_args args
+          backend_class.enqueue(method, resource_class, resource_id, *args)
+        end
 
-      private
-
-      def stringify_args(args)
-        args.map do |a|
-          case a
-            when Hash
-              a.stringify_keys
-            when Symbol
-              a.to_s
-            else
-              a
+        private
+  
+        def stringify_args(args)
+          args.map do |a|
+            case a
+              when Hash
+                a.stringify_keys
+              when Symbol
+                a.to_s
+              else
+                a
+            end
           end
         end
-      end
-
-      def backend_class
-        Backend.for(Devise::Async.backend)
-      end
+  
+        def backend_class
+          Backend.for(Devise::Async.backend)
         end
+      end
     end
   end
 end


### PR DESCRIPTION
In Rails default queue name for ActionMailer in ActiveJob is `:mailers`.
Rails 4: https://github.com/rails/rails/blob/4-2-stable/actionmailer/lib/action_mailer/delivery_job.rb#L7
Rails 5: https://github.com/rails/rails/blob/master/actionmailer/lib/action_mailer/delivery_methods.rb#L20
