### PR TITLE
Make queue used by ActionMailer job configurable

### DIFF
--- a/lib/devise/async.rb
+++ b/lib/devise/async.rb
@@ -1,12 +1,17 @@
 require 'devise'
 require 'devise/async/model'
 require 'devise/async/version'
+require 'action_mailer'
 
 module Devise
   module Async
     # Defines the enabled configuration that if set to false the emails will be sent synchronously
     mattr_accessor :enabled
     @@enabled = true
+
+    # Defines the queue in which the background job will be enqueued.
+    mattr_accessor :queue
+    @@queue = ActionMailer::Base.deliver_later_queue_name
 
     # Allow configuring Devise::Async with a block
     #

--- a/lib/devise/async/model.rb
+++ b/lib/devise/async/model.rb
@@ -50,7 +50,9 @@ module Devise
       private
 
       def deliver_mail_later(notification, model, args)
-        devise_mailer.send(notification, model, *args).deliver_later
+        devise_mailer.
+          send(notification, model, *args).
+          deliver_later(queue: Devise::Async.queue)
       end
     end
   end

--- a/spec/devise/async_spec.rb
+++ b/spec/devise/async_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe Devise::Async do
     expect(described_class.enabled).to eq(false)
     described_class.enabled = initial_enabled
   end
+
+  it 'stores queue config' do
+    initial_queue = described_class.queue
+
+    described_class.queue = :critical
+    expect(described_class.queue).to eq(:critical)
+    described_class.queue = initial_queue
+  end
 end


### PR DESCRIPTION
`Devise::Async.queue` was previously configurable when backends could be configured, and this PR brings that feature back.

ActionMailer lets us choose what queue to use on each call to [`#deliver_later`](https://api.rubyonrails.org/classes/ActionMailer/MessageDelivery.html#method-i-deliver_later), and we leverage that in this PR. `Devise::Async.queue` will default to `ActionMailer::Base.deliver_later_queue_name` (which [defaults to `:mailers`](https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/actionmailer/lib/action_mailer/delivery_methods.rb#L15)).